### PR TITLE
feat: add zod validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-atoms",
-  "version": "1.3.0-next.2",
+  "version": "0.0.0-semantic-release",
   "description": "Form primitives for Jotai",
   "license": "MIT",
   "author": "Jared Lunde <jared.lunde@gmail.com> (https://jaredlunde.com/)",
@@ -9,19 +9,19 @@
   "bugs": "https://github.com/jaredLunde/form-atoms/issues",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.mjs"
-      },
+      "import": "./dist/index.mjs",
       "module": "./dist/index.mjs",
       "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./zod": {
+      "import": "./dist/zod.mjs",
+      "module": "./dist/zod.mjs",
+      "default": "./dist/zod.js",
+      "types": "./dist/zod.d.ts"
+    },
     "./*": {
-      "import": {
-        "types": "./dist/*.d.ts",
-        "default": "./dist/*.mjs"
-      },
+      "import": "./dist/*.mjs",
       "module": "./dist/*.mjs",
       "default": "./dist/*.js",
       "types": "./dist/*.d.ts"
@@ -115,7 +115,10 @@
     "extends": [
       "lunde",
       "plugin:prettier/recommended"
-    ]
+    ],
+    "rules": {
+      "jsdoc/no-undefined-types": "off"
+    }
   },
   "eslintIgnore": [
     "node_modules",
@@ -157,14 +160,19 @@
         "@semantic-release/git",
         {
           "assets": [
-            "types",
-            "CHANGELOG.md",
-            "package.json"
+            "CHANGELOG.md"
           ],
           "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
         }
       ],
       "@semantic-release/github"
     ]
+  },
+  "typesVersions": {
+    "*": {
+      "zod": [
+        "dist/zod.d.ts"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,17 +9,27 @@
   "bugs": "https://github.com/jaredLunde/form-atoms/issues",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "module": "./dist/index.mjs",
+      "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./zod": {
-      "import": "./dist/zod.js",
-      "types": "./dist/zod.d.ts"
+    "./*": {
+      "import": {
+        "types": "./dist/*.d.ts",
+        "default": "./dist/*.mjs"
+      },
+      "module": "./dist/*.mjs",
+      "default": "./dist/*.js",
+      "types": "./dist/*.d.ts"
     },
     "./package.json": "./package.json"
   },
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/index.mjs",
   "files": [
     "/dist"
   ],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./zod": {
+      "import": "./dist/zod.js",
+      "types": "./dist/zod.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "main": "dist/main/index.js",
@@ -72,7 +76,8 @@
     "semantic-release": "^20.1.0",
     "tsup": "^6.5.0",
     "typescript": "^4.9.4",
-    "vitest": "^0.28.3"
+    "vitest": "^0.28.3",
+    "zod": "^3.20.2"
   },
   "keywords": [
     "atomic form",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ specifiers:
   tsup: ^6.5.0
   typescript: ^4.9.4
   vitest: ^0.28.3
+  zod: ^3.20.2
 
 dependencies:
   "@testing-library/user-event": 13.5.0
@@ -65,6 +66,7 @@ devDependencies:
   tsup: 6.5.0_typescript@4.9.4
   typescript: 4.9.4
   vitest: 0.28.3_happy-dom@8.2.0
+  zod: 3.20.2
 
 packages:
   /@adobe/css-tools/4.1.0:
@@ -9686,4 +9688,11 @@ packages:
         integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==,
       }
     engines: { node: ">=12.20" }
+    dev: true
+
+  /zod/3.20.2:
+    resolution:
+      {
+        integrity: sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==,
+      }
     dev: true

--- a/src/zod.test.tsx
+++ b/src/zod.test.tsx
@@ -1,0 +1,185 @@
+import { act as domAct, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { zodValidate } from "./zod";
+
+import { fieldAtom, useFieldAtom } from ".";
+
+describe("zodValidate()", () => {
+  it("should validate without a config", async () => {
+    const nameAtom = fieldAtom({
+      value: "",
+      validate: zodValidate(z.string().min(3, "3 plz")),
+    });
+
+    const field = renderHook(() => useFieldAtom(nameAtom));
+
+    domAct(() => {
+      field.result.current.actions.validate();
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("invalid");
+    expect(field.result.current.state.errors).toEqual(["3 plz"]);
+  });
+
+  it("should throw multiple errors", async () => {
+    const nameAtom = fieldAtom({
+      value: "",
+      validate: zodValidate(
+        z.string().min(3, "3 plz").regex(/foo/, "must match foo"),
+        {
+          fatal: false,
+        }
+      ),
+    });
+
+    const field = renderHook(() => useFieldAtom(nameAtom));
+
+    domAct(() => {
+      field.result.current.actions.validate();
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("invalid");
+    expect(field.result.current.state.errors).toEqual([
+      "3 plz",
+      "must match foo",
+    ]);
+  });
+  it("should use custom error formatting", async () => {
+    const nameAtom = fieldAtom({
+      value: "",
+      validate: zodValidate(
+        z.string().min(3, "3 plz").regex(/foo/, "must match foo"),
+        {
+          formatError: (err) =>
+            err.errors.map((e) =>
+              JSON.stringify({ code: e.code, message: e.message })
+            ),
+          fatal: false,
+        }
+      ),
+    });
+
+    const field = renderHook(() => useFieldAtom(nameAtom));
+
+    domAct(() => {
+      field.result.current.actions.validate();
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("invalid");
+    expect(field.result.current.state.errors).toEqual([
+      JSON.stringify({ code: "too_small", message: "3 plz" }),
+      JSON.stringify({ code: "invalid_string", message: "must match foo" }),
+    ]);
+  });
+
+  it("should validate 'on' a given event", async () => {
+    const nameAtom = fieldAtom({
+      value: "",
+      validate: zodValidate(z.string().min(3, "3 plz"), { on: "change" }),
+    });
+
+    const field = renderHook(() => useFieldAtom(nameAtom));
+
+    domAct(() => {
+      field.result.current.actions.validate();
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("valid");
+    expect(field.result.current.state.errors).toEqual([]);
+
+    domAct(() => {
+      field.result.current.actions.setValue("f");
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("invalid");
+    expect(field.result.current.state.errors).toEqual(["3 plz"]);
+  });
+
+  it("should validate only when dirty", async () => {
+    const nameAtom = fieldAtom({
+      value: "",
+      validate: zodValidate(z.string().min(3, "3 plz"), {
+        ifDirty: true,
+      }),
+    });
+
+    const field = renderHook(() => useFieldAtom(nameAtom));
+
+    domAct(() => {
+      field.result.current.actions.validate();
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("valid");
+    expect(field.result.current.state.errors).toEqual([]);
+
+    domAct(() => {
+      field.result.current.actions.setValue("f");
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("invalid");
+    expect(field.result.current.state.errors).toEqual(["3 plz"]);
+  });
+
+  it("should validate only when touched", async () => {
+    const nameAtom = fieldAtom({
+      value: "",
+      validate: zodValidate(z.string().min(3, "3 plz"), {
+        ifTouched: true,
+      }),
+    });
+
+    const field = renderHook(() => useFieldAtom(nameAtom));
+
+    domAct(() => {
+      field.result.current.actions.setTouched(true);
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("invalid");
+    expect(field.result.current.state.errors).toEqual(["3 plz"]);
+  });
+
+  it("should validate multiple conditions", async () => {
+    const nameAtom = fieldAtom({
+      value: "",
+      validate: zodValidate(z.string().min(3, "3 plz"), {
+        on: "user",
+      }).or({ on: "change", ifDirty: true }),
+    });
+
+    const field = renderHook(() => useFieldAtom(nameAtom));
+
+    domAct(() => {
+      field.result.current.actions.validate();
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("invalid");
+    expect(field.result.current.state.errors).toEqual(["3 plz"]);
+
+    domAct(() => {
+      field.result.current.actions.setValue("foo bar");
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("valid");
+    expect(field.result.current.state.errors).toEqual([]);
+
+    domAct(() => {
+      field.result.current.actions.setValue("fo");
+    });
+
+    await domAct(() => Promise.resolve());
+    expect(field.result.current.state.validateStatus).toBe("invalid");
+    expect(field.result.current.state.errors).toEqual(["3 plz"]);
+  });
+});

--- a/src/zod.test.tsx
+++ b/src/zod.test.tsx
@@ -156,11 +156,6 @@ describe("zodValidate()", () => {
 
     const field = renderHook(() => useFieldAtom(nameAtom));
 
-    domAct(() => {
-      field.result.current.actions.validate();
-    });
-
-    await domAct(() => Promise.resolve());
     expect(field.result.current.state.validateStatus).toBe("valid");
     expect(field.result.current.state.errors).toEqual([]);
 
@@ -177,6 +172,7 @@ describe("zodValidate()", () => {
     const nameAtom = fieldAtom({
       value: "",
       validate: zodValidate(z.string().min(3, "3 plz"), {
+        on: "change",
         ifDirty: true,
       }),
     });
@@ -204,6 +200,7 @@ describe("zodValidate()", () => {
     const nameAtom = fieldAtom({
       value: "",
       validate: zodValidate(z.string().min(3, "3 plz"), {
+        on: "change",
         ifTouched: true,
       }),
     });
@@ -215,6 +212,12 @@ describe("zodValidate()", () => {
     });
 
     await domAct(() => Promise.resolve());
+
+    domAct(() => {
+      field.result.current.actions.setValue("ab");
+    });
+
+    await domAct(() => Promise.resolve());
     expect(field.result.current.state.validateStatus).toBe("invalid");
     expect(field.result.current.state.errors).toEqual(["3 plz"]);
   });
@@ -222,9 +225,10 @@ describe("zodValidate()", () => {
   it("should validate multiple conditions", async () => {
     const nameAtom = fieldAtom({
       value: "",
-      validate: zodValidate(z.string().min(3, "3 plz"), {
-        on: "user",
-      }).or({ on: "change", ifDirty: true }),
+      validate: zodValidate(z.string().min(3, "3 plz")).or({
+        on: "change",
+        ifDirty: true,
+      }),
     });
 
     const field = renderHook(() => useFieldAtom(nameAtom));
@@ -278,7 +282,7 @@ describe("zodValidate()", () => {
           throw new Error("foo");
         })
         // @ts-expect-error
-      )({ value: "foo" });
+      )({ value: "foo", event: "user" });
     }).rejects.toThrow();
   });
 });

--- a/src/zod.test.tsx
+++ b/src/zod.test.tsx
@@ -1,5 +1,5 @@
 import { act as domAct, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { zodValidate } from "./zod";
@@ -48,6 +48,7 @@ describe("zodValidate()", () => {
       "must match foo",
     ]);
   });
+
   it("should use custom error formatting", async () => {
     const nameAtom = fieldAtom({
       value: "",

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import type { Getter } from "jotai";
+import type { z } from "zod";
+import { ZodError, ZodType } from "zod";
+
+import type { FieldAtomValidateOn, Validate } from ".";
+
+/**
+ * Validate your field atoms with Zod schemas.
+ *
+ * @param schema - Zod schema or a function that returns a Zod schema
+ * @param config - Configuration options
+ */
+export function zodValidate<Value>(
+  schema: ((get: Getter) => z.Schema) | z.Schema,
+  config: ZodValidateConfig = {}
+) {
+  const {
+    on,
+    ifDirty,
+    ifTouched,
+    formatError = (err) => err.flatten().formErrors,
+    fatal = false,
+  } = config;
+  const ors: ((
+    state: Parameters<Exclude<Validate<Value>, undefined>>[0]
+  ) => Promise<string[] | undefined>)[] = [];
+
+  const chain = Object.assign(
+    async (
+      state: Parameters<Exclude<Validate<Value>, undefined>>[0]
+    ): Promise<string[] | undefined> => {
+      let result: string[] | undefined;
+      const shouldHandleEvent = !on || on.includes(state.event);
+
+      if (shouldHandleEvent) {
+        const shouldHandleDirty =
+          ifDirty === undefined || ifDirty === state.dirty;
+        const shouldHandleTouched =
+          ifTouched === undefined || ifTouched === state.touched;
+
+        if (shouldHandleDirty && shouldHandleTouched) {
+          const validator =
+            schema instanceof ZodType ? schema : schema(state.get);
+
+          try {
+            await validator.parseAsync(state.value);
+            result = [];
+          } catch (err) {
+            if (err instanceof ZodError) {
+              return formatError(err);
+            }
+
+            throw err;
+          }
+        }
+      }
+
+      if (ors.length > 0) {
+        for (const or of ors) {
+          const errors = await or(state);
+
+          if (errors?.length) {
+            result = errors;
+            break;
+          } else if (errors) {
+            result = errors;
+          }
+
+          if (fatal && result) {
+            return result;
+          }
+        }
+      }
+
+      return result;
+    },
+    {
+      or(config: Omit<ZodValidateConfig, "fatal" | "formatError">) {
+        const or = zodValidate(schema, { formatError, fatal, ...config });
+        ors.push(or);
+        return chain;
+      },
+    }
+  );
+
+  return chain;
+}
+
+export type ZodValidateConfig = {
+  /**
+   * The event or events that triggers validation.
+   */
+  on?: FieldAtomValidateOn | FieldAtomValidateOn[];
+  /**
+   * Validate if the field has been touched.
+   */
+  ifTouched?: boolean;
+  /**
+   * Validate if the field is dirty.
+   */
+  ifDirty?: boolean;
+  /**
+   * Format the error message returned by the validator.
+   *
+   * @param error - A ZodError object
+   */
+  formatError?: (error: ZodError) => string[];
+  /**
+   * If true, the validation will stop after the first error.
+   *
+   * @default false
+   */
+  fatal?: boolean;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
-    "target": "es2016",
+    "target": "ES2018",
     "module": "ESNext",
     "declaration": false,
     "esModuleInterop": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,10 +5,10 @@ import tsconfig from "./tsconfig.json";
 export default defineConfig({
   name: "form-atoms",
   entry: ["src/index.tsx", "src/zod.ts"],
-  format: "esm",
+  format: ["esm", "cjs"],
   dts: true,
   clean: true,
   minify: true,
-  outExtension: () => ({ js: ".js" }),
+  external: ["zod"],
   target: tsconfig.compilerOptions.target,
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,7 @@ import tsconfig from "./tsconfig.json";
 
 export default defineConfig({
   name: "form-atoms",
-  entry: ["src/index.tsx"],
+  entry: ["src/index.tsx", "src/zod.ts"],
   format: "esm",
   dts: true,
   clean: true,


### PR DESCRIPTION
- Add initial Zod validator design to `form-atoms/zod`

### Type signature

```ts
import { Getter } from "jotai";
import { z, ZodError } from "zod";
import { Validate, FieldAtomValidateOn } from "./index.js";

/**
 * Validate your field atoms with Zod schemas. This function validates
 * on every "user" and "submit" event, in addition to other events you specify.
 *
 * @param schema - Zod schema or a function that returns a Zod schema
 * @param config - Configuration options
 * @example
 * ```ts
 * const schema = z.object({
 *  name: z.string().min(3),
 * });
 *
 * const nameForm = formAtom({
 *   name: fieldAtom({
 *     validate: zodValidate(schema.shape.name, {
 *       on: "blur",
 *     })
 *   })
 * })
 * ```
 */
declare function zodValidate<Value>(
  schema: ((get: Getter) => z.Schema) | z.Schema,
  config?: ZodValidateConfig
): ((
  state: Parameters<Exclude<Validate<Value>, undefined>>[0]
) => Promise<string[] | undefined>) & {
  or(
    config: Omit<ZodValidateConfig, "failFast" | "formatError">
  ): ((
    state: Parameters<Exclude<Validate<Value>, undefined>>[0]
  ) => Promise<string[] | undefined>) &
    any;
};
```

### Configuration

```ts
export type ZodValidateConfig = {
  /**
   * The event or events that triggers validation.
   */
  on?: FieldAtomValidateOn | FieldAtomValidateOn[];
  /**
   * Validate if the field has been touched.
   */
  ifTouched?: boolean;
  /**
   * Validate if the field is dirty.
   */
  ifDirty?: boolean;
  /**
   * Format the error message returned by the validator.
   *
   * @param error - A ZodError object
   */
  formatError?: (error: ZodError) => string[];
  /**
   * If `true`, the validation will only report the first error in the chain.
   * If `false`, the validation will report all errors in the chain.
   *
   * @default true
   */
  failFast?: boolean;
};
```

### Usage

#### Without options

```ts
const nameAtom = fieldAtom({
  value: "",
  validate: zodValidate(z.string().min(3, "3 plz")),
});
```

#### With custom formatting

```ts
const nameAtom = fieldAtom({
  value: "",
  validate: zodValidate(
    z.string().min(3, "3 plz").regex(/foo/, "must match foo"),
    {
      formatError: (err) =>
        err.errors.map((e) =>
          JSON.stringify({ code: e.code, message: e.message })
        ),
    }
  ),
});
```

#### With multiple conditions

```ts
const nameAtom = fieldAtom({
  value: "",
  validate: zodValidate(z.string().min(3, "3 plz"), {
    on: "user",
  }).or({ on: "change", ifDirty: true }),
});
```
