### PR TITLE
feat: flatten output of form values, errors and touched fields generics

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1314,7 +1314,7 @@ export type FormErrors<Form extends FormAtom<any>> = Form extends FormAtom<
 /**
  * An object containing the values of a form's nested field atoms
  */
-export type FormFieldValues<Fields extends FormFields> = {
+export type FormFieldValues<Fields extends FormFields> = Flatten<{
   [Key in keyof Fields]: Fields[Key] extends FieldAtom<infer Value>
     ? Value
     : Fields[Key] extends FormFields
@@ -1326,12 +1326,12 @@ export type FormFieldValues<Fields extends FormFields> = {
       ? FormFieldValues<Item>[]
       : never
     : never;
-};
+}>;
 
 /**
  * An object containing the errors of a form's nested field atoms
  */
-export type FormFieldErrors<Fields extends FormFields> = {
+export type FormFieldErrors<Fields extends FormFields> = Flatten<{
   [Key in keyof Fields]: Fields[Key] extends FieldAtom<any>
     ? string[]
     : Fields[Key] extends FormFields
@@ -1343,12 +1343,12 @@ export type FormFieldErrors<Fields extends FormFields> = {
       ? FormFieldErrors<Item>[]
       : never
     : never;
-};
+}>;
 
 /**
  * An object containing the errors of a form's touched fields
  */
-export type TouchedFields<Fields extends FormFields> = {
+export type TouchedFields<Fields extends FormFields> = Flatten<{
   [Key in keyof Fields]: Fields[Key] extends FieldAtom<any>
     ? boolean
     : Fields[Key] extends FormFields
@@ -1360,7 +1360,7 @@ export type TouchedFields<Fields extends FormFields> = {
       ? TouchedFields<Item>[]
       : never
     : never;
-};
+}>;
 
 export type UseForm<Fields extends FormFields> = {
   /**
@@ -1691,3 +1691,6 @@ export type UseAtomOptions = {
    */
   store?: AtomStore;
 };
+
+type Flatten<T> = Identity<{ [K in keyof T]: T[K] }>;
+type Identity<T> = T;


### PR DESCRIPTION
The `flatten` type helps resolve recursive generic calls, making the output readable.

previously [for test input](https://github.com/jaredLunde/form-atoms/blob/bd4a1d93785c0c1357f3c04c070e7f282a229da3/src/index.test.tsx#L993):
```ts
type V = {
    cities: FormFieldValues<{
        name: FieldAtom<string>;
        people: {
            name: FieldAtom<string>[];
        }[];
    }>[];
}
type V = FormFieldValues<typeof config>;
```

Currently:
```ts
type V = {
    cities: {
        name: string;
        people: {
            name: string[];
        }[];
    }[];
}
type V = FormFieldValues<typeof config>;
```

This is an improvement to half-done issue: https://github.com/jaredLunde/form-atoms/issues/27

This hacky type appears in different names, alternatives are `Compute` or `Prettify`.
I've used [`flatten` which is used in the zod library](https://github.com/colinhacks/zod/blob/eebbf70cfa087fea6128397a316342b6ebe10b1f/src/types.ts#L1831)

