### PR TITLE
feat: add select/textarea and add rich input types to hooks

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "buildCommand": "build",
-  "sandboxes": ["/examples/async-zod"],
+  "sandboxes": ["/examples/async-zod", "/examples/basic"],
   "node": "18"
 }

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ by using it, but you gain a ton of performance and without footguns.
 1. [**How to create a nested fields**](https://codesandbox.io/s/form-atoms-v2-nested-fields-example-lirr6w)
 1. [**How to create an array of fields**](https://codesandbox.io/s/form-atoms-v2-array-fields-example-22kf4d?file=/src/App.tsx)
 
+## Projects using `form-atoms`
+
+- [**@form-atoms/field**](https://github.com/MiroslavPetrik/form-atoms-field) - Declarative & headless form fields build on top of Jotai & form-atoms
+
 ---
 
 ## Field atoms

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "form-atoms-validate-zod",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.tsx",
+  "scripts": {
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "start": "react-scripts start",
+    "test": "react-scripts test --env=jsdom"
+  },
+  "dependencies": {
+    "jotai": "^2.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "react-scripts": "^5.0.0",
+    "typescript": "^4.9.0"
+  },
+  "keywords": [],
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "form-atoms-validate-zod",
+  "name": "form-atoms-basic",
   "version": "1.0.0",
   "description": "",
   "main": "src/index.tsx",

--- a/examples/basic/public/index.html
+++ b/examples/basic/public/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+    <title>React App</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css"
+    />
+  </head>
+
+  <body>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+  </body>
+</html>

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { zodValidate } from "form-atoms/zod";
 import {
   formAtom,
   fieldAtom,

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -54,7 +54,7 @@ export default function ValidateOn() {
               <label>
                 <span>Name</span>
 
-                <FieldErrors atom={fieldAtoms.name}>
+                <FieldErrors atom={fieldAtoms.text}>
                   <InputField
                     atom={fieldAtoms.text}
                     initialValue={String(Math.random())}
@@ -111,7 +111,7 @@ export default function ValidateOn() {
                 <FieldErrors atom={fieldAtoms.select}>
                   <SelectField
                     atom={fieldAtoms.select}
-                    initialValue="1"
+                    initialValue="2"
                     render={(props) => {
                       return (
                         <select {...props}>
@@ -127,7 +127,7 @@ export default function ValidateOn() {
                 <FieldErrors atom={fieldAtoms.selectMultiple}>
                   <SelectField
                     atom={fieldAtoms.selectMultiple}
-                    initialValue={["1"]}
+                    initialValue={["1", "3"]}
                     multiple
                     render={(props) => {
                       return (
@@ -145,6 +145,7 @@ export default function ValidateOn() {
                   <TextareaField
                     atom={fieldAtoms.textarea}
                     initialValue="Hello world"
+                    component="textarea"
                   />
                 </FieldErrors>
               </label>

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -20,6 +20,15 @@ export const nameFormAtom = formAtom({
   datetimeLocal: fieldAtom<Date>({
     value: new Date(),
   }),
+  month: fieldAtom<Date>({
+    value: new Date(),
+  }),
+  week: fieldAtom<Date>({
+    value: new Date(),
+  }),
+  time: fieldAtom<Date>({
+    value: new Date(),
+  }),
   number: fieldAtom({
     value: 0,
   }),
@@ -78,6 +87,36 @@ export default function ValidateOn() {
                     initialValue={new Date(Date.now() + 24 * 60 * 60 * 1000)}
                     component="input"
                     type="datetime-local"
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.month}>
+                  <InputField
+                    atom={fieldAtoms.month}
+                    // Tomorrow
+                    initialValue={new Date(Date.now() + 24 * 60 * 60 * 1000)}
+                    component="input"
+                    type="month"
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.week}>
+                  <InputField
+                    atom={fieldAtoms.week}
+                    // Tomorrow
+                    initialValue={new Date(Date.now() + 24 * 60 * 60 * 1000)}
+                    component="input"
+                    type="week"
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.time}>
+                  <InputField
+                    atom={fieldAtoms.time}
+                    // Tomorrow
+                    initialValue={new Date(Date.now() + 24 * 60 * 60 * 1000)}
+                    component="input"
+                    type="time"
                   />
                 </FieldErrors>
 

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { zodValidate } from "form-atoms/zod";
+import {
+  formAtom,
+  fieldAtom,
+  InputField,
+  SelectField,
+  TextareaField,
+  Form,
+} from "form-atoms";
+import { FieldErrors } from "./components/field-errors";
+
+export const nameFormAtom = formAtom({
+  text: fieldAtom({
+    value: "",
+  }),
+  date: fieldAtom<Date | null>({
+    value: null,
+  }),
+  datetimeLocal: fieldAtom<Date>({
+    value: new Date(),
+  }),
+  number: fieldAtom({
+    value: 0,
+  }),
+  range: fieldAtom({
+    value: 0,
+  }),
+  files: fieldAtom<FileList | null>({
+    value: null,
+  }),
+  select: fieldAtom({
+    value: "1",
+  }),
+  selectMultiple: fieldAtom({
+    value: ["1"],
+  }),
+  textarea: fieldAtom({
+    value: "",
+  }),
+});
+
+export default function ValidateOn() {
+  return (
+    <Template title="Validate a field asynchronously">
+      <Form
+        atom={nameFormAtom}
+        render={({ submit, fieldAtoms, reset }) => {
+          return (
+            <form
+              onSubmit={submit((values) => alert(JSON.stringify(values)))}
+              onReset={reset}
+            >
+              <label>
+                <span>Name</span>
+
+                <FieldErrors atom={fieldAtoms.name}>
+                  <InputField
+                    atom={fieldAtoms.text}
+                    initialValue={String(Math.random())}
+                    component="input"
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.date}>
+                  <InputField
+                    atom={fieldAtoms.date}
+                    initialValue={null}
+                    component="input"
+                    type="date"
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.datetimeLocal}>
+                  <InputField
+                    atom={fieldAtoms.datetimeLocal}
+                    // Tomorrow
+                    initialValue={new Date(Date.now() + 24 * 60 * 60 * 1000)}
+                    component="input"
+                    type="datetime-local"
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.number}>
+                  <InputField
+                    atom={fieldAtoms.number}
+                    initialValue={12}
+                    component="input"
+                    type="number"
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.range}>
+                  <InputField
+                    atom={fieldAtoms.range}
+                    initialValue={12}
+                    component="input"
+                    type="range"
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.files}>
+                  <InputField
+                    atom={fieldAtoms.files}
+                    initialValue={null}
+                    component="input"
+                    type="file"
+                  />
+                </FieldErrors>
+              </label>
+
+              <button type="submit">Submit</button>
+              <button type="reset" className="outline">
+                Reset
+              </button>
+            </form>
+          );
+        }}
+      />
+    </Template>
+  );
+}
+
+function Template({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ padding: "32px 64px" }}>
+      <blockquote style={{ margin: 0 }}>
+        <h3 style={{ margin: 0 }}>form-atoms</h3>
+        {title}
+      </blockquote>
+      <hr style={{ margin: "32px auto" }} />
+      {children}
+    </div>
+  );
+}

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -107,6 +107,46 @@ export default function ValidateOn() {
                     type="file"
                   />
                 </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.select}>
+                  <SelectField
+                    atom={fieldAtoms.select}
+                    initialValue="1"
+                    render={(props) => {
+                      return (
+                        <select {...props}>
+                          <option value="1">One</option>
+                          <option value="2">Two</option>
+                          <option value="3">Three</option>
+                        </select>
+                      );
+                    }}
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.selectMultiple}>
+                  <SelectField
+                    atom={fieldAtoms.selectMultiple}
+                    initialValue={["1"]}
+                    multiple
+                    render={(props) => {
+                      return (
+                        <select {...props}>
+                          <option value="1">One</option>
+                          <option value="2">Two</option>
+                          <option value="3">Three</option>
+                        </select>
+                      );
+                    }}
+                  />
+                </FieldErrors>
+
+                <FieldErrors atom={fieldAtoms.textarea}>
+                  <TextareaField
+                    atom={fieldAtoms.textarea}
+                    initialValue="Hello world"
+                  />
+                </FieldErrors>
               </label>
 
               <button type="submit">Submit</button>

--- a/examples/basic/src/components/field-errors.tsx
+++ b/examples/basic/src/components/field-errors.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { useFieldErrors, useFieldState } from "form-atoms";
+import type { FieldAtom } from "form-atoms";
+
+export function FieldErrors<Value>({
+  atom,
+  children,
+}: {
+  atom: FieldAtom<Value>;
+  children: React.ReactElement;
+}) {
+  // @ts-expect-error: useId() exists brah
+  const id = React.useId();
+  const { validateStatus } = useFieldState(atom);
+  const errors = useFieldErrors(atom);
+  return (
+    <div>
+      {React.cloneElement(children, {
+        "aria-describedby": errors.length > 0 ? id : undefined,
+      })}
+
+      {validateStatus === "validating" && (
+        <div id={id} aria-busy="true" style={{ marginBottom: "1em" }}>
+          Validating...
+        </div>
+      )}
+
+      {validateStatus === "invalid" && errors.length > 0 && (
+        <div id={id} style={{ marginBottom: "1em" }}>
+          ⚠️ {errors.join("\n")}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/basic/src/index.tsx
+++ b/examples/basic/src/index.tsx
@@ -1,0 +1,6 @@
+import { createRoot } from "react-dom/client";
+
+import App from "./App";
+
+const rootElement = document.getElementById("root");
+if (rootElement) createRoot(rootElement).render(<App />);

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "isolatedModules": true
+  }
+}

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -13,6 +13,8 @@ import {
   Field,
   Form,
   InputField,
+  SelectField,
+  TextareaField,
   fieldAtom,
   formAtom,
   useFieldErrors,
@@ -26,6 +28,8 @@ import {
   useFormSubmit,
   useFormValues,
   useInputField,
+  useSelectField,
+  useTextareaField,
 } from ".";
 
 vi.useFakeTimers();
@@ -146,6 +150,224 @@ describe("<InputField>", () => {
 
     render(
       <InputField
+        atom={atom}
+        initialValue="hello"
+        render={(props, state, actions) => {
+          return (
+            <button onClick={() => actions.setValue("foo")}>
+              {state.value}
+            </button>
+          );
+        }}
+      />
+    );
+
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it('should render "component" prop in scope w/ date type', () => {
+    const atom = fieldAtom<Date | null>({ name: "date", value: null });
+    render(
+      <InputField
+        atom={atom}
+        type="date"
+        component={(props) => <input data-testid="input" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("input")).toHaveAttribute("type", "date");
+  });
+
+  it('should render "component" prop in scope w/ datetime-local type', () => {
+    const atom = fieldAtom<Date | null>({ value: null });
+    render(
+      <InputField
+        atom={atom}
+        type="datetime-local"
+        component={(props) => <input data-testid="input" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("input")).toHaveAttribute(
+      "type",
+      "datetime-local"
+    );
+  });
+
+  it('should render "component" prop in scope w/ month type', () => {
+    const atom = fieldAtom<Date | null>({ value: null });
+    render(
+      <InputField
+        atom={atom}
+        type="month"
+        component={(props) => <input data-testid="input" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("input")).toHaveAttribute("type", "month");
+  });
+
+  it('should render "component" prop in scope w/ week type', () => {
+    const atom = fieldAtom<Date | null>({ value: null });
+    render(
+      <InputField
+        atom={atom}
+        type="week"
+        component={(props) => <input data-testid="input" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("input")).toHaveAttribute("type", "week");
+  });
+
+  it('should render "component" prop in scope w/ time type', () => {
+    const atom = fieldAtom<Date | null>({ value: null });
+    render(
+      <InputField
+        atom={atom}
+        type="time"
+        component={(props) => <input data-testid="input" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("input")).toHaveAttribute("type", "time");
+  });
+
+  it('should render "component" prop in scope w/ file type', () => {
+    const atom = fieldAtom<FileList | null>({ value: null });
+    render(
+      <InputField
+        atom={atom}
+        type="file"
+        component={(props) => <input data-testid="input" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("input")).toBeInTheDocument();
+  });
+
+  it('should render "component" prop in scope w/ number type', () => {
+    const atom = fieldAtom({ value: 0 });
+    render(
+      <InputField
+        atom={atom}
+        type="number"
+        component={(props) => <input data-testid="input" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("input")).toHaveAttribute("type", "number");
+  });
+
+  it('should render "component" prop in scope w/ range type', () => {
+    const atom = fieldAtom({ value: 0 });
+    render(<InputField atom={atom} type="range" component="input" />);
+    expect(screen.getByRole("slider")).toBeInTheDocument();
+  });
+});
+
+describe("<SelectField>", () => {
+  it('should render "component" prop in scope', () => {
+    const atom = fieldAtom({ value: "test" });
+    render(
+      <SelectField
+        atom={atom}
+        component={(props) => <select data-testid="select" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("select")).toBeInTheDocument();
+  });
+
+  it('should render "render" prop', () => {
+    const atom = fieldAtom({ value: "test" });
+    render(
+      <SelectField
+        atom={atom}
+        render={(props) => <select data-testid="select" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("select")).toBeInTheDocument();
+  });
+
+  it("should set initial value", () => {
+    const atom = fieldAtom({ value: "test" });
+
+    render(
+      <SelectField
+        atom={atom}
+        initialValue="hello"
+        render={(props, state, actions) => {
+          return (
+            <button onClick={() => actions.setValue("foo")}>
+              {state.value}
+            </button>
+          );
+        }}
+      />
+    );
+
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it('should render "component" with multiple prop in scope', () => {
+    const atom = fieldAtom({ value: ["test"] });
+    render(
+      <SelectField
+        atom={atom}
+        component={(props) => <select data-testid="select" {...props} />}
+        multiple
+      />
+    );
+    expect(screen.getByTestId("select")).toHaveAttribute("multiple");
+  });
+
+  it('should render multiple "render" prop', () => {
+    const atom = fieldAtom({ value: ["test"] });
+    render(
+      <SelectField
+        atom={atom}
+        multiple
+        render={(props) => <select data-testid="select" {...props} />}
+      />
+    );
+    expect(screen.getByTestId("select")).toHaveAttribute("multiple");
+  });
+
+  it("should set multiple initial values", () => {
+    const atom = fieldAtom({ value: ["test"] });
+
+    render(
+      <SelectField
+        atom={atom}
+        initialValue={["hello"]}
+        multiple
+        render={(props, state, actions) => {
+          return (
+            <button onClick={() => actions.setValue(["foo"])}>
+              {state.value.join("")}
+            </button>
+          );
+        }}
+      />
+    );
+
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+});
+
+describe("<TextareaField>", () => {
+  it('should render "component" prop in scope', () => {
+    const atom = fieldAtom({ value: "test" });
+    render(<TextareaField atom={atom} component="textarea" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it('should render "render" prop', () => {
+    const atom = fieldAtom({ value: "test" });
+    render(
+      <TextareaField atom={atom} render={(props) => <textarea {...props} />} />
+    );
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("should set initial value", () => {
+    const atom = fieldAtom({ value: "test" });
+
+    render(
+      <TextareaField
         atom={atom}
         initialValue="hello"
         render={(props, state, actions) => {
@@ -361,7 +583,9 @@ describe("useField()", () => {
     const firstNameAtom = fieldAtom(atomConfig);
     const { result } = renderHook(() => useInputField(firstNameAtom));
     domAct(() => {
-      result.current.props.onChange({ target: { value: "test" } } as any);
+      result.current.props.onChange({
+        currentTarget: { value: "test" },
+      } as any);
     });
 
     expect(atomConfig.validate).toHaveBeenCalledWith(
@@ -691,7 +915,7 @@ describe("useFieldInitialValue()", () => {
       useFieldInitialValue(firstNameAtom, "jared");
       return useInputField(firstNameAtom);
     });
-
+    field.result.current.props.type;
     expect(field.result.current.props.value).toBe("jared");
   });
 
@@ -792,6 +1016,111 @@ describe("useFieldErrors", () => {
       atom.result.current.actions.validate();
     });
     expect(result.current).toEqual(["error"]);
+  });
+});
+
+describe("useSelectField()", () => {
+  it("should be multiple", () => {
+    const atom = fieldAtom({
+      value: ["test"],
+    });
+    const { result } = renderHook(() =>
+      useSelectField(atom, { multiple: true })
+    );
+    expect(result.current.props.value).toStrictEqual(["test"]);
+    expect(result.current.props.multiple).toBe(true);
+    // @ts-expect-error
+    expect(result.current.props.type).toBe(undefined);
+
+    domAct(() => {
+      result.current.actions.setValue(["test", "test2"]);
+    });
+
+    expect(result.current.props.value).toStrictEqual(["test", "test2"]);
+  });
+
+  it("should be multiple onChange", () => {
+    const atom = fieldAtom({
+      value: ["test"],
+    });
+    const { result } = renderHook(() =>
+      useSelectField(atom, { multiple: true })
+    );
+    expect(result.current.props.value).toStrictEqual(["test"]);
+    expect(result.current.props.multiple).toBe(true);
+    // @ts-expect-error
+    expect(result.current.props.type).toBe(undefined);
+
+    domAct(() => {
+      result.current.props.onChange({
+        currentTarget: {
+          options: [
+            // @ts-expect-error
+            { value: "test", selected: true },
+            // @ts-expect-error
+            { value: "test2", selected: true },
+            // @ts-expect-error
+            { value: "test3", selected: false },
+          ],
+        },
+      });
+    });
+
+    expect(result.current.props.value).toStrictEqual(["test", "test2"]);
+  });
+
+  it("should be single by default", () => {
+    const atom = fieldAtom({
+      value: "",
+    });
+    const { result } = renderHook(() => useSelectField(atom));
+    expect(result.current.props.value).toBe("");
+    expect(result.current.props.multiple).toBe(undefined);
+
+    domAct(() => {
+      // @ts-expect-error
+      result.current.props.onChange({ currentTarget: { value: "test" } });
+    });
+
+    expect(result.current.props.value).toStrictEqual("test");
+  });
+
+  it("should have an initialValue", () => {
+    const atom = fieldAtom({
+      value: "",
+    });
+    const { result } = renderHook(() =>
+      useSelectField(atom, { initialValue: "test" })
+    );
+    expect(result.current.props.value).toBe("test");
+  });
+});
+
+describe("useTextareaField()", () => {
+  it("should change", () => {
+    const atom = fieldAtom({
+      value: "",
+    });
+    const { result } = renderHook(() => useTextareaField(atom));
+    expect(result.current.props.value).toBe("");
+    // @ts-expect-error
+    expect(result.current.props.type).toBe(undefined);
+
+    domAct(() => {
+      result.current.actions.setValue("test");
+    });
+
+    expect(result.current.props.value).toStrictEqual("test");
+  });
+
+  it("should have an initialValue", () => {
+    const atom = fieldAtom({
+      value: "",
+    });
+    const { result } = renderHook(() =>
+      useTextareaField(atom, { initialValue: "test" })
+    );
+    expect(result.current.props.value).toBe("test");
   });
 });
 
@@ -1635,11 +1964,9 @@ describe("useSubmit()", () => {
   });
 });
 
-function createTextField<Value extends string | number | readonly string[]>(
-  fieldAtom: FieldAtom<Value>
-) {
+function createTextField<Value extends string>(fieldAtom: FieldAtom<Value>) {
   return function Field() {
     const field = useInputField(fieldAtom);
-    return <input type="text" {...field.props} />;
+    return <input {...field.props} />;
   };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -861,10 +861,10 @@ const fileTypes = new Set(["file"] as const);
  */
 function formatDateString(date: Date, type: React.HTMLInputTypeAttribute) {
   // Adjust the date to account for the timezone offset.
-  date = dateWithTzOffset(date);
   const isoDate = date.toISOString();
 
   if (type === "date") {
+    date = dateWithTzOffset(date);
     return isoDate.slice(0, 10);
   } else if (type === "datetime-local") {
     // Formatted to YYYY-MM-DDTHH:mm

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -812,6 +812,8 @@ export function useInputFieldProps<
         setAnyValue(
           fileTypes.has(anyFieldType)
             ? target.files
+            : anyFieldType === "datetime-local"
+            ? new Date(target.valueAsNumber)
             : dateTypes.has(anyFieldType)
             ? target.valueAsDate
             : numberTypes.has(anyFieldType)
@@ -901,15 +903,7 @@ function formatDateString(date: Date, type: React.HTMLInputTypeAttribute) {
 function getIsoWeek(date: Date): string {
   date = dateWithTzOffset(date);
   date = new Date(
-    Date.UTC(
-      date.getFullYear(),
-      date.getMonth(),
-      date.getDate(),
-      date.getHours(),
-      date.getMinutes(),
-      date.getSeconds(),
-      date.getMilliseconds()
-    )
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
   );
   // Set to nearest Thursday: current date + 4 - current day number
   // Make Sunday's day number 7
@@ -921,10 +915,13 @@ function getIsoWeek(date: Date): string {
     ((date.getTime() - yearStart.getTime()) / 86400000 + 1) / 7
   );
   // Handle last week of the previous year
-  if (weekNo < 1) {
+  if (weekNo === 0) {
     const prevYearStart = new Date(Date.UTC(date.getUTCFullYear() - 1, 0, 1));
     weekNo = Math.ceil(
-      ((date.getTime() - prevYearStart.getTime()) / 86400000 + 1) / 7
+      ((date.getTime() - prevYearStart.getTime()) / 86400000 +
+        1 +
+        (isLeapYear(date.getUTCFullYear() - 1) ? 366 : 365)) /
+        7
     );
     return (
       date.getUTCFullYear() - 1 + "-W" + (weekNo < 10 ? "0" + weekNo : weekNo)
@@ -937,6 +934,10 @@ function getIsoWeek(date: Date): string {
 function dateWithTzOffset(date: Date): Date {
   const offset = date.getTimezoneOffset() / 60;
   return new Date(date.getTime() + offset * 60 * 60 * 1000);
+}
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 }
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -858,6 +858,8 @@ const fileTypes = new Set(["file"] as const);
  * @param type - The type of input.
  */
 function formatDateString(date: Date, type: React.HTMLInputTypeAttribute) {
+  // Adjust the date to account for the timezone offset.
+  date = dateWithTzOffset(date);
   const isoDate = date.toISOString();
 
   if (type === "date") {
@@ -897,9 +899,17 @@ function formatDateString(date: Date, type: React.HTMLInputTypeAttribute) {
  * All other years have 52 weeks.
  */
 function getIsoWeek(date: Date): string {
-  // Copy date so don't modify original
+  date = dateWithTzOffset(date);
   date = new Date(
-    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds(),
+      date.getMilliseconds()
+    )
   );
   // Set to nearest Thursday: current date + 4 - current day number
   // Make Sunday's day number 7
@@ -922,6 +932,11 @@ function getIsoWeek(date: Date): string {
   }
   // Return array of year and week number
   return date.getUTCFullYear() + "-W" + ("" + weekNo).padStart(2, "0");
+}
+
+function dateWithTzOffset(date: Date): Date {
+  const offset = date.getTimezoneOffset() / 60;
+  return new Date(date.getTime() + offset * 60 * 60 * 1000);
 }
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -399,10 +399,15 @@ export function useForm<Fields extends FormFields>(
           validate("user");
         });
       },
-      reset,
+      reset(event) {
+        event?.preventDefault();
+        startTransition(() => {
+          reset();
+        });
+      },
       submit(onSubmit) {
-        return (e) => {
-          e?.preventDefault();
+        return (event) => {
+          event?.preventDefault();
           startTransition(() => {
             handleSubmit(onSubmit);
           });
@@ -1667,7 +1672,7 @@ export type UseForm<Fields extends FormFields> = {
    */
   submit(
     handleSubmit: (values: FormFieldValues<Fields>) => void | Promise<void>
-  ): (e?: React.FormEvent<HTMLFormElement>) => void;
+  ): (event?: React.FormEvent<HTMLFormElement>) => void;
   /**
    * A function that validates the form's nested field atoms with a
    * `"user"` validation event.
@@ -1677,7 +1682,7 @@ export type UseForm<Fields extends FormFields> = {
    * A function that resets the form's nested field atoms to their
    * initial states.
    */
-  reset(): void;
+  reset(event?: React.FormEvent<HTMLFormElement>): void;
 };
 
 export type UseFormStatus = {
@@ -1693,7 +1698,7 @@ export type UseFormStatus = {
 
 export type UseFormSubmit<Fields extends FormFields> = {
   (values: (value: FormFieldValues<Fields>) => void | Promise<void>): (
-    e?: React.FormEvent<HTMLFormElement>
+    event?: React.FormEvent<HTMLFormElement>
   ) => void;
 };
 
@@ -1751,7 +1756,7 @@ export type UseFormActions<Fields extends FormFields> = {
    */
   submit(
     handleSubmit: (values: FormFieldValues<Fields>) => void | Promise<void>
-  ): (e?: React.FormEvent<HTMLFormElement>) => void;
+  ): (event?: React.FormEvent<HTMLFormElement>) => void;
   /**
    * A function that validates the form's nested field atoms with a
    * `"user"` validation event.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -932,8 +932,8 @@ function getIsoWeek(date: Date): string {
 }
 
 function dateWithTzOffset(date: Date): Date {
-  const offset = date.getTimezoneOffset() / 60;
-  return new Date(date.getTime() + offset * 60 * 60 * 1000);
+  const tzOffset = new Date().getTimezoneOffset() * 60 * 1000;
+  return new Date(date.getTime() + tzOffset);
 }
 
 function isLeapYear(year: number): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,3 +16,97 @@ export function setPath(target: any, paths: string[], value: unknown) {
     }
   }
 }
+
+/**
+ * Formats a date string based on the type of input. This is necessary because
+ * HTML expects different formats for different input types. For example,
+ * `date` expects a date in the format `YYYY-MM-DD` while `datetime-local`
+ * expects a date in the format `YYYY-MM-DDTHH:mm`.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats
+ * @param date - The date to format.
+ * @param type - The type of input.
+ */
+export function formatDateString(
+  date: Date,
+  type: React.HTMLInputTypeAttribute
+) {
+  // Adjust the date to account for the timezone offset.
+  const isoDate = date.toISOString();
+
+  if (type === "datetime-local") {
+    // Formatted to YYYY-MM-DDTHH:mm
+    return isoDate.slice(0, 16);
+  } else if (type === "month") {
+    // 2001-06
+    return isoDate.slice(0, 7);
+  } else if (type === "week") {
+    // Format is YYYY-Www where YYYY is the year and ww is the week number.
+    return getIsoWeek(date);
+  } else if (type === "time") {
+    // The value of the time in the 24-hour format e.g. `15:30`
+    return isoDate.slice(11, 19);
+  }
+
+  date = removeTzOffset(date);
+  return isoDate.slice(0, 10);
+}
+
+/**
+ * Gets the week number of a date.
+ * 
+ * The week of the year is a two-digit string between 01 and 53. Each week begins
+ * on Monday and ends on Sunday. That means it's possible for the first few days of
+ * January to be considered part of the previous week-year, and for the last few days
+ * of December to be considered part of the following week-year. The first week of the
+ * year is the week that contains the first Thursday of the year. For example, the first
+ * Thursday of 1953 was on January 1, so that week—beginning on Monday, December 29—
+ * is considered the first week of the year. Therefore, December 30, 1952 occurs during
+ * the week 1953-W01.
+ 
+ * A year has 53 weeks if:
+ *   The first day of the calendar year (January 1) is a Thursday or
+ *   The first day of the year (January 1) is a Wednesday and the year is a leap year
+ * All other years have 52 weeks.
+ */
+function getIsoWeek(date: Date): string {
+  date = removeTzOffset(date);
+  date = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  );
+  // Set to nearest Thursday: current date + 4 - current day number
+  // Make Sunday's day number 7
+  date.setUTCDate(date.getUTCDate() + 4 - (date.getUTCDay() || 7));
+  let year = date.getUTCFullYear();
+  // Start of the year
+  const startUtcTime = new Date(
+    Date.UTC(date.getUTCFullYear(), 0, 1)
+  ).getTime();
+  const time = date.getTime();
+  // Calculate full weeks to nearest Thursday
+  let weekNo = Math.ceil(((time - startUtcTime) / dayMs + 1) / 7);
+  // Handle last week of the previous year
+  if (weekNo === 0) {
+    const prevYear = year - 1;
+    const prevYearStartTime = new Date(Date.UTC(prevYear, 0, 1)).getTime();
+    weekNo = Math.ceil(
+      ((time - prevYearStartTime) / dayMs +
+        1 +
+        (isLeapYear(prevYear) ? 366 : 365)) /
+        7
+    );
+    year = prevYear;
+  }
+  // Return array of year and week number
+  return year + "-W" + ("" + weekNo).padStart(2, "0");
+}
+
+const dayMs = 86400000; // 24 * 60 * 60 * 1000
+
+function removeTzOffset(date: Date): Date {
+  return new Date(date.getTime() + new Date().getTimezoneOffset() * 60 * 1000);
+}
+
+function isLeapYear(year: number): boolean {
+  return !(year % 4 || (!(year % 100) && year % 400));
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ export function formatDateString(
   }
 
   date = removeTzOffset(date);
-  return isoDate.slice(0, 10);
+  return date.toISOString().slice(0, 10);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,7 +92,8 @@ function getIsoWeek(date: Date): string {
     weekNo = Math.ceil(
       ((time - prevYearStartTime) / dayMs +
         1 +
-        (isLeapYear(prevYear) ? 366 : 365)) /
+        // If the year is a leap year, add 1 day
+        (!(year % 4 || (!(year % 100) && year % 400)) ? 366 : 365)) /
         7
     );
     year = prevYear;
@@ -105,8 +106,4 @@ const dayMs = 86400000; // 24 * 60 * 60 * 1000
 
 function removeTzOffset(date: Date): Date {
   return new Date(date.getTime() + new Date().getTimezoneOffset() * 60 * 1000);
-}
-
-function isLeapYear(year: number): boolean {
-  return !(year % 4 || (!(year % 100) && year % 400));
 }


### PR DESCRIPTION
Remove select/textarea types from `useInputField()`. Add `useSelectField()`, `useTextareaField()` hooks.
Add `type` option to `useInputField()`.

BREAKING CHANGE: Remove select/textarea types from useInputField().

fix https://github.com/jaredLunde/form-atoms/issues/36

### TODO

- [ ] Docs